### PR TITLE
fix(seq): emit digits(start) width so first value has no leading zeros

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,12 @@ Content-Length: 72
 
 At runtime: `"id":100001`, `"id":100002`, `"id":100003`, ... (never repeats)
 
+The width of the emitted value equals `digits(start)`, so the counter can grow within that digit band without changing Content-Length. Pick a `start` with enough digits to cover the expected number of increments — e.g. `{SEQ:10000001}` supports ~89M increments with 8-digit width. Starting near a power of ten (e.g. `{SEQ:999995}`) is not recommended, since the counter will quickly roll past the width.
+
 ### How it works
 
-- Values are **zero-padded** to a fixed width (digits of max value), so Content-Length stays correct and buffer size never changes
+- `{RAND}` values are **zero-padded** to `digits(max)`, keeping Content-Length stable. Safe for URL path segments; avoid placing `{RAND}` inside a JSON number field unless `min` and `max` share the same digit count, since leading zeros are invalid JSON numbers per RFC 8259.
+- `{SEQ}` values are written at `digits(start)` width — no leading zeros, so `{SEQ:start}` is safe inside JSON number fields.
 - `{RAND}` uses per-connection state — no atomic operations, no lock contention
 - `{SEQ}` uses a single `atomic_fetch_add` per request — ~10 ns overhead
 - One placeholder per template (first `{RAND:` or `{SEQ:` found)

--- a/src/main.c
+++ b/src/main.c
@@ -158,8 +158,13 @@ static int scan_placeholder(char **buf, int *len, placeholder_t *ph)
         ph->min = start;
         ph->max = 0;
         atomic_store(&ph->seq, start);
-        ph->width = count_digits(start + 10000000); /* room for growth */
-        if (ph->width < 6) ph->width = 6;
+        /* Width matches digits(start) so the first emitted value has no
+         * leading zeros. JSON number fields reject leading zeros per
+         * RFC 8259, so anything else silently corrupts POST bodies.
+         * Users who need the counter to grow past 10^digits(start)
+         * must pick a start with enough digit headroom — e.g.
+         * {SEQ:10000001} covers ~89M increments with 8-digit width. */
+        ph->width = count_digits(start);
     } else {
         return 0;
     }


### PR DESCRIPTION
## Summary

Fixes #14 — `{SEQ:start}` no longer zero-pads beyond `start`'s digit count, so the first emitted value is a valid JSON number.

Width was `count_digits(start + 10_000_000)` (min 6), which for a 6-digit start like `{SEQ:100001}` gave an 8-digit slot and emitted `"00100001"`. That leading zero is rejected by every RFC 8259 JSON parser (System.Text.Json, serde_json, jackson, encoding/json, …), so any POST template with `{SEQ:}` inside a JSON number field silently broke with 100% 5xx.

New width is `count_digits(start)`. The first value equals `start` (from the existing `atomic_store`) and fits exactly, no leading zeros.

## Trade-off

The previous `+10_000_000` gave an implicit 10M-increment growth budget before Content-Length drifted. Now the user owns that budget explicitly by picking a `start` with enough digit headroom (e.g. `{SEQ:10000001}` gives ~89M increments at 8-digit width). I think this is the right trade — breaking JSON silently is much worse than asking users to choose a start size that fits their run, and the README example (`{SEQ:100001}`) already implied "values start at 100001 and grow" without ever hinting at implicit padding.

## Not changed

`{RAND}` padding (`count_digits(max)`) is unchanged. Its values are almost always used in URL path segments where leading zeros parse fine, so the same bug is latent but rarely bites. README now flags it explicitly so users pick a `min`/`max` with matching digit count if they put RAND inside a JSON number field.

## Test plan

Tested via HttpArena's CRUD profile (which triggered the bug report). Before this patch, the committed `{SEQ:100001}` fixture produced 100% POST failures (`per-template-ok[0..2] = 0,0,0`). After:

- `./scripts/benchmark.sh aspnet-minimal crud` at 512c → 91K rps, **0 4xx/5xx**, creates succeed (`per-template-ok[0..2] = 37K,37K,37K`)
- Same at 4096c → 91K rps, **0 4xx/5xx**, same clean distribution

No changes to `{RAND}`, no changes to the emission path (`write_padded` in `worker.c`) — width narrows, everything else is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)